### PR TITLE
pdf2csv: errors handling + formatting args on the CLI

### DIFF
--- a/scraptils/tools/pdf2csv.py
+++ b/scraptils/tools/pdf2csv.py
@@ -25,8 +25,13 @@ class UnicodeWriter:
         self.encoder = codecs.getincrementalencoder(encoding)()
 
     def writerow(self, row):
-        self.writer.writerow([s.encode("utf-8") if isinstance(s, basestring) else s
-                              for s in row])
+        try:
+            self.writer.writerow(
+                [s.encode("utf-8") if isinstance(s, basestring) else s
+                    for s in row])
+        except UnicodeDecodeError:
+            self.writer.writerow( ["?"*len(s) for s in row] )
+
         # Fetch UTF-8 output from the queue ...
         data = self.queue.getvalue()
         data = data.decode("utf-8")

--- a/scraptils/tools/pdf2csv.py
+++ b/scraptils/tools/pdf2csv.py
@@ -99,6 +99,9 @@ def pdf2csv(pdf):
     fp.close()
 
 def filterclose(lst):
+    if not lst:
+        return []
+
     tmp=[lst[0]]
     for elem in islice(lst, 1, None):
         if elem - 2 > tmp[-1]:

--- a/scraptils/tools/pdf2csv.py
+++ b/scraptils/tools/pdf2csv.py
@@ -47,7 +47,7 @@ class UnicodeWriter:
             self.writerow(row)
 
 
-def pdf2csv(pdf):
+def pdf2csv(pdf, **kwds):
     fp = open(pdf, 'rb')
     parser = PDFParser(fp)
     doc = PDFDocument()
@@ -62,7 +62,7 @@ def pdf2csv(pdf):
     device = PDFPageAggregator(rsrcmgr, laparams=laparams)
     interpreter = PDFPageInterpreter(rsrcmgr, device)
 
-    writer = UnicodeWriter(sys.stdout)
+    writer = UnicodeWriter(sys.stdout, **kwds)
     for pageno, page in enumerate(doc.get_pages()):
         interpreter.process_page(page)
         layout = device.get_result()
@@ -125,4 +125,14 @@ def get_region(pdf, page, x1,y1,x2,y2):
                      )
 
 if __name__=='__main__':
-    pdf2csv(sys.argv[1])
+    filename=sys.argv[1]
+    fmtargs = sys.argv[2:]
+    if fmtargs:
+        kwargs = {}
+        for arg in fmtargs:
+            key,val = arg.strip().split("=")
+            kwargs[key] = val
+        pdf2csv(filename, **kwargs)
+    else:
+        pdf2csv(filename)
+


### PR DESCRIPTION
feature: formatting args to the CSV writer from the CLI

```
This permits to call the script with formatting options to be passed to the CSV writer.
Use the form "name=value" after the pdf file name.
For example, to change the delimiter:
    ./pdf2csv.py my_file.pdf delimiter=@
May not work with arguments expecting something different than a string.
```

bugfix: do not crash on empty lists
bugfix: catch decode error and write "?"s instead
